### PR TITLE
CreateCommand -- Rename "--no-db" to "--skip-db" and "--no-url" to "--skip-url"

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ A: Each application should have its own directory (eg
 directory corresponds to a single virtual-host and a single MySQL database.
 If you need an additional virtual-host and DB for that application, call
 "create" again with the "--name" argument.  If you want an additional
-virtual-host XOR DB, specify "--no-db" or "--no-url".
+virtual-host XOR DB, specify "--skip-db" or "--skip-url".
 
 Q: How do I build a stand-alone PHAR executable for amp?
 

--- a/src/Amp/Command/CreateCommand.php
+++ b/src/Amp/Command/CreateCommand.php
@@ -38,8 +38,8 @@ class CreateCommand extends ContainerAwareCommand {
       ->setDescription('Create a MySQL+HTTPD instance')
       ->addOption('root', 'r', InputOption::VALUE_REQUIRED, 'The local path to the document root', getcwd())
       ->addOption('name', 'N', InputOption::VALUE_REQUIRED, 'Brief technical identifier for the service', '')
-      ->addOption('no-db', NULL, InputOption::VALUE_NONE, 'Do not generate a DB')
-      ->addOption('no-url', NULL, InputOption::VALUE_NONE, 'Do not expose on the web')
+      ->addOption('skip-db', NULL, InputOption::VALUE_NONE, 'Do not generate a DB')
+      ->addOption('skip-url', NULL, InputOption::VALUE_NONE, 'Do not expose on the web')
       ->addOption('url', NULL, InputOption::VALUE_REQUIRED, 'Specify the preferred web URL for this service. (Omit to auto-generate)')
       ->addOption('force', 'f', InputOption::VALUE_NONE, 'Overwrite any pre-existing httpd/mysql container')
       ->addOption('prefix', NULL, InputOption::VALUE_REQUIRED, 'Prefix to place in front of each outputted variable', 'AMP_')
@@ -78,7 +78,7 @@ class CreateCommand extends ContainerAwareCommand {
       $instance->setUrl($input->getOption('url'));
     }
 
-    $this->instances->create($instance, !$input->getOption('no-url'), !$input->getOption('no-db'));
+    $this->instances->create($instance, !$input->getOption('skip-url'), !$input->getOption('skip-db'));
     $this->instances->save();
 
     if ($output->getVerbosity() > OutputInterface::VERBOSITY_QUIET) {


### PR DESCRIPTION
There's a subtle distinction -- when forcing (overwriting/recreating), the
"--skip-db" option will do nothing (leave the DB alone); the "--no-db"
option suggests that the DB should not exist.
