### PR TITLE
Locking - Explicitly acquire a lock depending on the command

### DIFF
--- a/src/Amp/Command/CleanupCommand.php
+++ b/src/Amp/Command/CleanupCommand.php
@@ -40,6 +40,7 @@ class CleanupCommand extends ContainerAwareCommand {
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {
+    $this->instances->lock();
     $count = 0;
     foreach ($this->instances->findAll() as $instance) {
       if ($input->getOption('force') || !file_exists($instance->getRoot())) {

--- a/src/Amp/Command/CreateCommand.php
+++ b/src/Amp/Command/CreateCommand.php
@@ -59,6 +59,8 @@ class CreateCommand extends ContainerAwareCommand {
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {
+    $this->instances->lock();
+
     $container = $this->getContainer();
     $mysql_type = $container->getParameter('mysql_type');
     if ($mysql_type == "") {

--- a/src/Amp/Command/DestroyCommand.php
+++ b/src/Amp/Command/DestroyCommand.php
@@ -52,6 +52,7 @@ class DestroyCommand extends ContainerAwareCommand {
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {
+    $this->instances->lock();
     $instance = $this->instances->find(Instance::makeId($input->getOption('root'), $input->getOption('name')));
     if (!$instance) {
       return;

--- a/src/Amp/Command/TestCommand.php
+++ b/src/Amp/Command/TestCommand.php
@@ -49,6 +49,8 @@ class TestCommand extends ContainerAwareCommand {
 
 
   protected function execute(InputInterface $input, OutputInterface $output) {
+    $this->instances->lock();
+
     // Display help text
     //$output->write($this->templateEngine->render('testing.php', array(
     //  'apache_dir' => $this->getContainer()->getParameter('apache_dir'),


### PR DESCRIPTION
Commands which modify instances.yml should acquire a lock before doing
anything.  Commands which merely read may proceed without acquiring the
lock.

This addresses an issue where running "amp sql" interactively causes all
other amp commands to fail.
