### PR TITLE
Allow each amp instance to override the nginx vhost template

### DIFF
--- a/app/defaults/services.yml
+++ b/app/defaults/services.yml
@@ -137,7 +137,7 @@ services:
     class: Amp\Httpd\VhostTemplate
     calls:
       - [setTemplateEngine, ['@template.engine']]
-      - [setTemplate, ['%apache_tpl%']]
+      - [setDefaultTemplate, ['%apache_tpl%']]
       - [setDir, ['%apache_dir%']]
       - [setLogDir, ['%log_dir%']]
       - [setPerm, ['@perm']]
@@ -149,7 +149,7 @@ services:
     class: Amp\Httpd\VhostTemplate
     calls:
       - [setTemplateEngine, ['@template.engine']]
-      - [setTemplate, ['%apache24_tpl%']]
+      - [setDefaultTemplate, ['%apache24_tpl%']]
       - [setDir, ['%apache_dir%']]
       - [setLogDir, ['%log_dir%']]
       - [setPerm, ['@perm']]
@@ -161,7 +161,7 @@ services:
     class: Amp\Httpd\VhostTemplate
     calls:
       - [setTemplateEngine, ['@template.engine']]
-      - [setTemplate, ['%nginx_tpl%']]
+      - [setDefaultTemplate, ['%nginx_tpl%']]
       - [setDir, ['%nginx_dir%']]
       - [setLogDir, ['%log_dir%']]
       - [setPerm, ['@perm']]

--- a/app/defaults/services.yml
+++ b/app/defaults/services.yml
@@ -136,6 +136,7 @@ services:
   httpd.apache:
     class: Amp\Httpd\VhostTemplate
     calls:
+      - [setConfigKey, ['apache']]
       - [setTemplateEngine, ['@template.engine']]
       - [setDefaultTemplate, ['%apache_tpl%']]
       - [setDir, ['%apache_dir%']]
@@ -148,6 +149,7 @@ services:
   httpd.apache24:
     class: Amp\Httpd\VhostTemplate
     calls:
+      - [setConfigKey, ['apache24']]
       - [setTemplateEngine, ['@template.engine']]
       - [setDefaultTemplate, ['%apache24_tpl%']]
       - [setDir, ['%apache_dir%']]
@@ -160,6 +162,7 @@ services:
   httpd.nginx:
     class: Amp\Httpd\VhostTemplate
     calls:
+      - [setConfigKey, ['nginx']]
       - [setTemplateEngine, ['@template.engine']]
       - [setDefaultTemplate, ['%nginx_tpl%']]
       - [setDir, ['%nginx_dir%']]

--- a/src/Amp/Command/CreateCommand.php
+++ b/src/Amp/Command/CreateCommand.php
@@ -95,7 +95,7 @@ Or by creating a file in the web-root (or its parent):
     if ($input->getOption('url')) {
       $url = $input->getOption('url');
       $urlScheme = parse_url($url, PHP_URL_SCHEME);
-      if(!$urlScheme){
+      if (!$urlScheme) {
         $url = 'http://' . ltrim($url, '/');
       }
       $instance->setUrl($url);

--- a/src/Amp/Command/CreateCommand.php
+++ b/src/Amp/Command/CreateCommand.php
@@ -38,7 +38,27 @@ class CreateCommand extends ContainerAwareCommand {
       ->addOption('force', 'f', InputOption::VALUE_NONE, 'Overwrite any pre-existing httpd/db container')
       ->addOption('perm', NULL, InputOption::VALUE_REQUIRED, 'Permission level of the DB User ("admin","super")', "admin")
       ->addOption('prefix', NULL, InputOption::VALUE_REQUIRED, 'Prefix to place in front of each outputted variable', 'AMP_')
-      ->addOption('output-file', 'o', InputOption::VALUE_REQUIRED, 'Output environment variables to file instead of stdout');
+      ->addOption('output-file', 'o', InputOption::VALUE_REQUIRED, 'Output environment variables to file instead of stdout')
+      ->setHelp('
+Create a SQL database and HTTP virtual host.
+
+The database credentials and HTTP configuration are determined by
+the current configuration. For more, see "amp config".
+
+Note: Some applications may require custom HTTP configurations,
+especially if deployed on nginx. You can override the default
+HTTP template by setting an environment variable:
+
+ * NGINX_VHOST_TPL=/path/to/my-template.php
+ * APACHE_VHOST_TPL=/path/to/my-template.php
+ * APACHE24_VHOST_TPL=/path/to/my-template.php
+
+Or by creating a file in the web-root (or its parent):
+
+ * .amp/nginx-vhost.php
+ * .amp/apache-vhost.php
+ * .amp/apache24-vhost.php
+');
   }
 
   protected function initialize(InputInterface $input, OutputInterface $output) {

--- a/src/Amp/Httpd/VhostTemplate.php
+++ b/src/Amp/Httpd/VhostTemplate.php
@@ -28,7 +28,7 @@ class VhostTemplate implements HttpdInterface {
   /**
    * @var string, name of the template file
    */
-  private $template;
+  private $defaultTemplate;
 
   /**
    * @var EngineInterface
@@ -74,7 +74,7 @@ class VhostTemplate implements HttpdInterface {
     $parameters['include_vhost_file'] = '';
     $parameters['log_dir'] = $this->getLogDir();
     $parameters['visibility'] = $visibility;
-    $content = $this->getTemplateEngine()->render($this->getTemplate(), $parameters);
+    $content = $this->getTemplateEngine()->render($this->getDefaultTemplate(), $parameters);
     $this->fs->dumpFile($this->createFilePath($root, $url), $content);
 
     $this->setupLogDir();
@@ -214,19 +214,18 @@ class VhostTemplate implements HttpdInterface {
     $this->httpd_shared_ports = $httpd_shared_ports;
   }
 
-
   /**
    * @param string $template
    */
-  public function setTemplate($template) {
-    $this->template = $template;
+  public function setDefaultTemplate($template) {
+    $this->defaultTemplate = $template;
   }
 
   /**
    * @return string
    */
-  public function getTemplate() {
-    return $this->template;
+  public function getDefaultTemplate() {
+    return $this->defaultTemplate;
   }
 
   /**

--- a/src/Amp/Httpd/VhostTemplate.php
+++ b/src/Amp/Httpd/VhostTemplate.php
@@ -36,6 +36,13 @@ class VhostTemplate implements HttpdInterface {
   private $templateEngine;
 
   /**
+   * @var string, a symbolic name for the template to lookup
+   *
+   * Ex: `nginx`, `apache24`.
+   */
+  private $configKey;
+
+  /**
    * @var string
    *   Maybe empty, 'NONE', or a command.
    */
@@ -74,7 +81,7 @@ class VhostTemplate implements HttpdInterface {
     $parameters['include_vhost_file'] = '';
     $parameters['log_dir'] = $this->getLogDir();
     $parameters['visibility'] = $visibility;
-    $content = $this->getTemplateEngine()->render($this->getDefaultTemplate(), $parameters);
+    $content = $this->getTemplateEngine()->render($this->pickTemplate($root, $url), $parameters);
     $this->fs->dumpFile($this->createFilePath($root, $url), $content);
 
     $this->setupLogDir();
@@ -91,6 +98,38 @@ class VhostTemplate implements HttpdInterface {
    */
   public function dropVhost($root, $url) {
     $this->fs->remove($this->createFilePath($root, $url));
+  }
+
+  /**
+   * Pick the most salient template for this build.
+   *
+   * For example, suppose we're searching on key `nginx`:
+   *  - If the env has variable NGINX_VHOST_TPL, use that.
+   *  - If the web-root or any parent has ".amp/nginx-vhost.php", use that.
+   *  - Otherwise, use the defaultTemplate.
+   *
+   * @param string $root local path to document root
+   * @param string $url preferred public URL
+   * @return string
+   */
+  public function pickTemplate($root, $url) {
+    $configKey = $this->getConfigKey();
+    $envVar = strtoupper($configKey) . '_VHOST_TPL';
+    if (getenv($envVar)) {
+      return getenv($envVar);
+    }
+
+    do {
+      $dir = !isset($dir) ? $root : dirname($dir);
+      $dotFile = $dir . DIRECTORY_SEPARATOR . '.amp'
+        . DIRECTORY_SEPARATOR . $configKey . '-vhost.php';
+      echo "check [$dotFile]\n";
+      if (file_exists($dotFile)) {
+        return $dotFile;
+      }
+    } while ($dir && $dir !== dirname($dir));
+
+    return $this->getDefaultTemplate();
   }
 
   public function restart() {
@@ -117,6 +156,20 @@ class VhostTemplate implements HttpdInterface {
       $parameters['port'] = 80;
     }
     return $this->getDir() . DIRECTORY_SEPARATOR . $parameters['host'] . '_' . $parameters['port'] . '.conf';
+  }
+
+  /**
+   * @return string
+   */
+  public function getConfigKey() {
+    return $this->configKey;
+  }
+
+  /**
+   * @param string $configKey
+   */
+  public function setConfigKey($configKey) {
+    $this->configKey = $configKey;
   }
 
   /**


### PR DESCRIPTION
In nginx, each application/instance is likely to need to a different configuration file -- for example, a Drupal template won't work with WordPress or Symfony. To resolve #21, the `amp create` command must be able to use different templates for different builds.

This revision performs a structured search to determine the template, e.g.
     * If the env has variable `NGINX_VHOST_TPL`, use that.
     * If the web-root or any parent has `.amp/nginx-vhost.php`, use that.
     * Otherwise, use the default template specified in `amp`.

The PR is not specific to nginx -- if the `httpd` type is set to `apache` or `apache24`, it will conduct a similar search (e.g. `APACHE_VHOST_TPL` and `.amp/apache-vhost.php`; or `APACHE24_VHOST_TPL` and `.amp/apache24-vhost.php`). However, the issue is most salient for nginx.