### PR TITLE
add instance visibility option, may be "all" or "local" (the default)

### DIFF
--- a/app/defaults/services.yml
+++ b/app/defaults/services.yml
@@ -72,6 +72,7 @@ services:
       - [setHosts, ['@hosts']]
       - [setHttpd, ['@httpd']]
       - [setLockWait, ['%instances_timeout%']]
+      - [setDefaultVisibility, ['%httpd_visibility%']]
 
   ## This database connection used for most environments
   # mysql.cli:

--- a/app/defaults/services.yml
+++ b/app/defaults/services.yml
@@ -7,6 +7,7 @@ parameters:
   # my_cnf_dir: '%app_dir%/my.cnf.d'
 
   httpd_type: 'apache'
+  httpd_visibility: 'all'
   httpd_shared_ports: '80'
   httpd_restart_wait: 1
   httpd_restart_command: ''

--- a/src/Amp/Command/ConfigCommand.php
+++ b/src/Amp/Command/ConfigCommand.php
@@ -346,8 +346,10 @@ class ConfigCommand extends ContainerAwareCommand {
           return $dialog->select($output,
             "Enter httpd_visibility",
             array(
-              'local' => 'Virtual hosts should bind to localhost',
-              'all' => 'Virtual hosts should bind to all available IP addresses',
+              'local' => "Virtual hosts should bind to localhost.\n"
+                . '         Recommended to avoid exposing local development instances.',
+              'all' => "Virtual hosts should bind to all available IP addresses.\n"
+                . '         <comment>Note</comment>: Instances will be publicly accessible over the network.',
             ),
             $default
           );

--- a/src/Amp/Command/ConfigCommand.php
+++ b/src/Amp/Command/ConfigCommand.php
@@ -117,6 +117,7 @@ class ConfigCommand extends ContainerAwareCommand {
     $output->writeln("");
     $output->writeln("<info>=============================[ Configure HTTPD ]=============================</info>");
     $this->askHttpdType()->execute($input, $output, $dialog);
+    $this->askHttpdVisibility()->execute($input, $output, $dialog);
 
     switch ($this->config->getParameter('httpd_type')) {
       case 'apache':
@@ -331,6 +332,22 @@ class ConfigCommand extends ContainerAwareCommand {
               'apache24' => 'Apache 2.4 or later',
               'nginx' => 'nginx (WIP)',
               'none' => 'None (Note: You must configure any vhosts manually.)',
+            ),
+            $default
+          );
+        }
+      );
+  }
+
+  protected function askHttpdVisibility() {
+    return $this->createPrompt('httpd_visibility')
+      ->setAsk(
+        function ($default, InputInterface $input, OutputInterface $output, DialogHelper $dialog) {
+          return $dialog->select($output,
+            "Enter httpd_visibility",
+            array(
+              'local' => 'Virtual hosts should bind to localhost',
+              'all' => 'Virtual hosts should bind to all available IP addresses',
             ),
             $default
           );

--- a/src/Amp/Command/CreateCommand.php
+++ b/src/Amp/Command/CreateCommand.php
@@ -34,6 +34,7 @@ class CreateCommand extends ContainerAwareCommand {
       ->addOption('skip-db', NULL, InputOption::VALUE_NONE, 'Do not generate a DB')
       ->addOption('skip-url', NULL, InputOption::VALUE_NONE, 'Do not expose on the web')
       ->addOption('url', NULL, InputOption::VALUE_REQUIRED, 'Specify the preferred web URL for this service. (Omit to auto-generate)')
+      ->addOption('visibility', NULL, InputOption::VALUE_REQUIRED, 'Which interfaces the vhost should be available on ("local","all")', 'local')
       ->addOption('force', 'f', InputOption::VALUE_NONE, 'Overwrite any pre-existing httpd/db container')
       ->addOption('perm', NULL, InputOption::VALUE_REQUIRED, 'Permission level of the DB User ("admin","super")', "admin")
       ->addOption('prefix', NULL, InputOption::VALUE_REQUIRED, 'Prefix to place in front of each outputted variable', 'AMP_')
@@ -73,6 +74,9 @@ class CreateCommand extends ContainerAwareCommand {
 
     if ($input->getOption('url')) {
       $instance->setUrl($input->getOption('url'));
+    }
+    if ($input->getOption('visibility')) {
+      $instance->setVisibility($input->getOption('visibility'));
     }
 
     $instances->create($instance, !$input->getOption('skip-url'), !$input->getOption('skip-db'), $input->getOption('perm'));

--- a/src/Amp/Command/CreateCommand.php
+++ b/src/Amp/Command/CreateCommand.php
@@ -34,7 +34,7 @@ class CreateCommand extends ContainerAwareCommand {
       ->addOption('skip-db', NULL, InputOption::VALUE_NONE, 'Do not generate a DB')
       ->addOption('skip-url', NULL, InputOption::VALUE_NONE, 'Do not expose on the web')
       ->addOption('url', NULL, InputOption::VALUE_REQUIRED, 'Specify the preferred web URL for this service. (Omit to auto-generate)')
-      ->addOption('visibility', NULL, InputOption::VALUE_REQUIRED, 'Which interfaces the vhost should be available on ("local","all")', 'local')
+      ->addOption('visibility', NULL, InputOption::VALUE_REQUIRED, 'Which interfaces the vhost should be available on ("local","all")', '')
       ->addOption('force', 'f', InputOption::VALUE_NONE, 'Overwrite any pre-existing httpd/db container')
       ->addOption('perm', NULL, InputOption::VALUE_REQUIRED, 'Permission level of the DB User ("admin","super")', "admin")
       ->addOption('prefix', NULL, InputOption::VALUE_REQUIRED, 'Prefix to place in front of each outputted variable', 'AMP_')

--- a/src/Amp/Command/ShowCommand.php
+++ b/src/Amp/Command/ShowCommand.php
@@ -31,6 +31,7 @@ class ShowCommand extends ContainerAwareCommand {
         $rows[] = array('name', $instance->getName());
         $rows[] = array('dsn', $instance->getDsn());
         $rows[] = array('url', $instance->getUrl());
+        $rows[] = array('visibility', $instance->getVisibility());
         $rows[] = array('', '');
       }
 
@@ -48,12 +49,13 @@ class ShowCommand extends ContainerAwareCommand {
           $instance->getName(),
           $instance->getDsn() ? 'y' : '',
           $instance->getUrl() ? 'y' : '',
+          $instance->getVisibility(),
         );
       }
 
       /** @var $table \Symfony\Component\Console\Helper\TableHelper */
       $table = $this->getApplication()->getHelperSet()->get('table');
-      $table->setHeaders(array('Root', 'Name', 'DB', 'Web'));
+      $table->setHeaders(array('Root', 'Name', 'DB', 'Web', 'Visibility'));
       $table->setRows($rows);
       $table->render($output);
       $output->writeln('For more detailed info, use "amp show -v" or "amp export [--root=X] [---name=X]');

--- a/src/Amp/ConfigRepository.php
+++ b/src/Amp/ConfigRepository.php
@@ -44,6 +44,7 @@ class ConfigRepository {
       'httpd_type' => 'Type of webserver [none,apache,apache24,nginx]',
       'httpd_restart_command' => 'Command to restart httpd (ex: sudo apache2ctl graceful)',
       'httpd_restart_wait' => 'Time to wait for HTTPD to restart (seconds)',
+      'httpd_visibility' => 'Default network visibility of new vhosts [local,all])',
       'httpd_shared_ports' => 'List of any http ports shared by multiple vhosts (comma-separated)',
       'hosts_type' => 'Type of hostname management [none,file]',
       'hosts_file' => 'Location of the hosts file (ex: /etc/hosts)',

--- a/src/Amp/Httpd/HttpdInterface.php
+++ b/src/Amp/Httpd/HttpdInterface.php
@@ -9,7 +9,7 @@ interface HttpdInterface {
    * @param string $url preferred public URL
    * @param string $visibility set to all to listen on all interfaces
    */
-  public function createVhost($root, $url, $visibility = 'local');
+  public function createVhost($root, $url, $visibility);
 
   /**
    * @param string $root local path to document root

--- a/src/Amp/Httpd/HttpdInterface.php
+++ b/src/Amp/Httpd/HttpdInterface.php
@@ -7,8 +7,9 @@ interface HttpdInterface {
   /**
    * @param string $root local path to document root
    * @param string $url preferred public URL
+   * @param string $visibility set to all to listen on all interfaces
    */
-  public function createVhost($root, $url);
+  public function createVhost($root, $url, $visibility = 'local');
 
   /**
    * @param string $root local path to document root

--- a/src/Amp/Httpd/None.php
+++ b/src/Amp/Httpd/None.php
@@ -11,7 +11,7 @@ class None implements HttpdInterface {
    * @param string $url preferred public URL
    * @param string $visibility set to all to listen on all interfaces
    */
-  public function createVhost($root, $url, $visibility = 'local') {
+  public function createVhost($root, $url, $visibility) {
     file_put_contents('php://stderr', "\n**** Please create the vhost for $url in $root ****\n\n", FILE_APPEND);
     $this->dirty = 1;
   }

--- a/src/Amp/Httpd/None.php
+++ b/src/Amp/Httpd/None.php
@@ -9,8 +9,9 @@ class None implements HttpdInterface {
   /**
    * @param string $root local path to document root
    * @param string $url preferred public URL
+   * @param string $visibility set to all to listen on all interfaces
    */
-  public function createVhost($root, $url) {
+  public function createVhost($root, $url, $visibility = 'local') {
     file_put_contents('php://stderr', "\n**** Please create the vhost for $url in $root ****\n\n", FILE_APPEND);
     $this->dirty = 1;
   }

--- a/src/Amp/Httpd/VhostTemplate.php
+++ b/src/Amp/Httpd/VhostTemplate.php
@@ -60,7 +60,7 @@ class VhostTemplate implements HttpdInterface {
    * @param string $url preferred public URL
    * @param string $visibility set to all to listen on all interfaces
    */
-  public function createVhost($root, $url, $visibility = 'local') {
+  public function createVhost($root, $url, $visibility) {
     $parameters = parse_url($url);
     if (!$parameters || !isset($parameters['host'])) {
       throw new \Exception("Failed to parse URL: " . $url);

--- a/src/Amp/Httpd/VhostTemplate.php
+++ b/src/Amp/Httpd/VhostTemplate.php
@@ -58,8 +58,9 @@ class VhostTemplate implements HttpdInterface {
   /**
    * @param string $root local path to document root
    * @param string $url preferred public URL
+   * @param string $visibility set to all to listen on all interfaces
    */
-  public function createVhost($root, $url) {
+  public function createVhost($root, $url, $visibility = 'local') {
     $parameters = parse_url($url);
     if (!$parameters || !isset($parameters['host'])) {
       throw new \Exception("Failed to parse URL: " . $url);
@@ -72,6 +73,7 @@ class VhostTemplate implements HttpdInterface {
     $parameters['url'] = $url;
     $parameters['include_vhost_file'] = '';
     $parameters['log_dir'] = $this->getLogDir();
+    $parameters['visibility'] = $visibility;
     $content = $this->getTemplateEngine()->render($this->getTemplate(), $parameters);
     $this->fs->dumpFile($this->createFilePath($root, $url), $content);
 

--- a/src/Amp/Instance.php
+++ b/src/Amp/Instance.php
@@ -29,7 +29,7 @@ class Instance {
    */
   private $visibility;
 
-  public function __construct($name = NULL, $dsn = NULL, $root = NULL, $url = NULL, $visibility = 'local') {
+  public function __construct($name = NULL, $dsn = NULL, $root = NULL, $url = NULL, $visibility = NULL) {
     $this->setName($name);
     $this->setDsn($dsn);
     $this->setRoot($root);

--- a/src/Amp/Instance.php
+++ b/src/Amp/Instance.php
@@ -24,11 +24,17 @@ class Instance {
    */
   private $url;
 
-  public function __construct($name = NULL, $dsn = NULL, $root = NULL, $url = NULL) {
+  /**
+   * @var string which interfaces vhost should be available on (local or all)
+   */
+  private $visibility;
+
+  public function __construct($name = NULL, $dsn = NULL, $root = NULL, $url = NULL, $visibility = 'local') {
     $this->setName($name);
     $this->setDsn($dsn);
     $this->setRoot($root);
     $this->setUrl($url);
+    $this->setVisibility($visibility);
   }
 
   /**
@@ -107,6 +113,20 @@ class Instance {
    */
   public function getUrl() {
     return $this->url;
+  }
+
+  /**
+   * @param string $visibility
+   */
+  public function setVisibility($visibility) {
+    $this->visibility = $visibility;
+  }
+
+  /**
+   * @return string
+   */
+  public function getVisibility() {
+    return $this->visibility;
   }
 
   public function getId() {

--- a/src/Amp/InstanceRepository.php
+++ b/src/Amp/InstanceRepository.php
@@ -53,7 +53,7 @@ class InstanceRepository extends FileRepository {
 
       $this->dirty['httpd'][] = $instance;
       $this->httpd->dropVhost($instance->getRoot(), $instance->getUrl());
-      $this->httpd->createVhost($instance->getRoot(), $instance->getUrl());
+      $this->httpd->createVhost($instance->getRoot(), $instance->getUrl(), $instance->getVisibility());
 
       $hostname = parse_url($instance->getUrl(), PHP_URL_HOST);
       $this->hosts->createHostname($hostname);
@@ -112,7 +112,7 @@ class InstanceRepository extends FileRepository {
    * @return Instance
    */
   public function decodeItem($array) {
-    return new Instance(@$array['name'], @$array['dsn'], @$array['root'], @$array['url']);
+    return new Instance(@$array['name'], @$array['dsn'], @$array['root'], @$array['url'], @$array['visibility']);
   }
 
   /**
@@ -125,6 +125,7 @@ class InstanceRepository extends FileRepository {
       'dsn' => $instance->getDsn(),
       'root' => $instance->getRoot(),
       'url' => $instance->getUrl(),
+      'visibility' => $instance->getVisibility(),
     );
   }
 

--- a/src/Amp/InstanceRepository.php
+++ b/src/Amp/InstanceRepository.php
@@ -21,6 +21,12 @@ class InstanceRepository extends FileRepository {
   private $httpd;
 
   /**
+   * @var string
+   *   ex: 'local', 'all'.
+   */
+  private $defaultVisibility;
+
+  /**
    * @var array
    *   Ex: Array('httpd' => array(Instance)).
    */
@@ -53,7 +59,8 @@ class InstanceRepository extends FileRepository {
 
       $this->dirty['httpd'][] = $instance;
       $this->httpd->dropVhost($instance->getRoot(), $instance->getUrl());
-      $this->httpd->createVhost($instance->getRoot(), $instance->getUrl(), $instance->getVisibility());
+      $visibility = $instance->getVisibility() ? $instance->getVisibility() : $this->getDefaultVisibility();
+      $this->httpd->createVhost($instance->getRoot(), $instance->getUrl(), $visibility);
 
       $hostname = parse_url($instance->getUrl(), PHP_URL_HOST);
       $this->hosts->createHostname($hostname);
@@ -171,6 +178,20 @@ class InstanceRepository extends FileRepository {
    */
   public function getHttpd() {
     return $this->httpd;
+  }
+
+  /**
+   * @return string
+   */
+  public function getDefaultVisibility() {
+    return $this->defaultVisibility;
+  }
+
+  /**
+   * @param string $defaultVisibility
+   */
+  public function setDefaultVisibility($defaultVisibility) {
+    $this->defaultVisibility = $defaultVisibility;
   }
 
 }

--- a/src/Amp/views/apache-vhost.php
+++ b/src/Amp/views/apache-vhost.php
@@ -5,12 +5,19 @@
  * @var string $host - the hostname to listen for
  * @var int $port - the port to listen for
  * @var string $include_vhost_file - the local path to a related config file
+ * @var string $visibility - which interfaces the vhost is available on
  */
 ?>
 
 <?php if ($use_listen) { ?>
 
+<?php if ($visibility === 'all'): ?>
 Listen <?php echo $port ?>
+<?php else: ?>
+Listen 127.0.0.1:<?php echo $port ?>
+
+Listen [::1]:<?php echo $port ?>
+<?php endif; ?>
 
 NameVirtualHost *:<?php echo $port ?>
 
@@ -30,7 +37,12 @@ NameVirtualHost *:<?php echo $port ?>
         Options All
         AllowOverride All
         Order allow,deny
+        <?php if ($visibility === 'all'): ?>
         Allow from all
+        <?php else: ?>
+        Allow from 127.0.0.0/8
+        Allow from ::1
+        <?php endif; ?>
     </Directory>
 
     <?php if (!empty($include_vhost_file)) { ?>

--- a/src/Amp/views/apache-vhost.php
+++ b/src/Amp/views/apache-vhost.php
@@ -15,8 +15,6 @@
 Listen <?php echo $port ?>
 <?php else: ?>
 Listen 127.0.0.1:<?php echo $port ?>
-
-Listen [::1]:<?php echo $port ?>
 <?php endif; ?>
 
 NameVirtualHost *:<?php echo $port ?>

--- a/src/Amp/views/apache24-vhost.php
+++ b/src/Amp/views/apache24-vhost.php
@@ -5,12 +5,19 @@
  * @var string $host - the hostname to listen for
  * @var int $port - the port to listen for
  * @var string $include_vhost_file - the local path to a related config file
+ * @var string $visibility - which interfaces the vhost is available on
  */
 
 ?>
 
 <?php if ($use_listen) { ?>
+<?php if ($visibility === 'all'): ?>
 Listen <?php echo $port ?>
+<?php else: ?>
+Listen 127.0.0.1:<?php echo $port ?>
+
+Listen [::1]:<?php echo $port ?>
+<?php endif; ?>
 <?php } ?>
 
 <VirtualHost *:<?php echo $port ?>>
@@ -26,10 +33,8 @@ Listen <?php echo $port ?>
     <Directory "<?php echo $root ?>">
         Options All
         AllowOverride All
-        Order allow,deny
-        Allow from all
         <IfModule mod_authz_host.c>
-            Require all granted
+            Require <?php echo $visibility ?> granted
         </IfModule>
     </Directory>
 

--- a/src/Amp/views/apache24-vhost.php
+++ b/src/Amp/views/apache24-vhost.php
@@ -15,8 +15,6 @@
 Listen <?php echo $port ?>
 <?php else: ?>
 Listen 127.0.0.1:<?php echo $port ?>
-
-Listen [::1]:<?php echo $port ?>
 <?php endif; ?>
 <?php } ?>
 

--- a/src/Amp/views/nginx-vhost.php
+++ b/src/Amp/views/nginx-vhost.php
@@ -12,10 +12,8 @@ server {
   server_name <?php echo $host; ?>;
   <?php if ($visibility === 'all'): ?>
   listen <?php echo $port ?>;
-  listen [::]:<?php echo $port ?>;
   <?php else: ?>
   listen 127.0.0.1:<?php echo $port ?>;
-  listen [::1]:<?php echo $port ?>;
   <?php endif; ?>
   root <?php echo $root; ?>;
 

--- a/src/Amp/views/nginx-vhost.php
+++ b/src/Amp/views/nginx-vhost.php
@@ -5,11 +5,18 @@
  * @var string $host - the hostname to listen for
  * @var int $port - the port to listen for
  * @var string $include_vhost_file - the local path to a related config file
+ * @var string $visibility - which interfaces the vhost is available on
  */
 ?>
 server {
   server_name <?php echo $host; ?>;
+  <?php if ($visibility === 'all'): ?>
   listen <?php echo $port ?>;
+  listen [::]:<?php echo $port ?>;
+  <?php else: ?>
+  listen 127.0.0.1:<?php echo $port ?>;
+  listen [::1]:<?php echo $port ?>;
+  <?php endif; ?>
   root <?php echo $root; ?>;
 
   <?php if (!empty($include_vhost_file)) { ?>


### PR DESCRIPTION
This option makes it easier to setup an httpd vhost which is only available on localhost (to avoid creating attack surface or exposing a private instance to the network).  We default to local-only (using a combination of listen directives plus access control such as `require local granted`).