### PR TITLE
CreateCommand - Assume http:// for --url if not present

### DIFF
--- a/src/Amp/Command/CreateCommand.php
+++ b/src/Amp/Command/CreateCommand.php
@@ -72,7 +72,12 @@ class CreateCommand extends ContainerAwareCommand {
     }
 
     if ($input->getOption('url')) {
-      $instance->setUrl($input->getOption('url'));
+      $url = $input->getOption('url');
+      $urlScheme = parse_url($url, PHP_URL_SCHEME);
+      if(!$urlScheme){
+        $url = 'http://' . ltrim($url, '/');
+      }
+      $instance->setUrl($url);
     }
 
     $instances->create($instance, !$input->getOption('skip-url'), !$input->getOption('skip-db'), $input->getOption('perm'));


### PR DESCRIPTION
This will check for scheme of `--url` option in the commands and if no scheme component is supplied, it will assume `http://` as the scheme and append it to the url.

---

civicrm/civicrm-buildkit#300

