### PR TITLE
Fix DSN parasing for php7.2

### DIFF
--- a/src/DB/DSN.php
+++ b/src/DB/DSN.php
@@ -103,7 +103,7 @@ class DSN {
       $parsed['dbsyntax'] = $str;
     }
 
-    if (!count($dsn)) {
+    if (!strlen($dsn)) {
       return $parsed;
     }
 

--- a/src/DB/DSN.php
+++ b/src/DB/DSN.php
@@ -103,7 +103,7 @@ class DSN {
       $parsed['dbsyntax'] = $str;
     }
 
-    if (!strlen($dsn)) {
+    if (empty($dsn)) {
       return $parsed;
     }
 


### PR DESCRIPTION
ping @totten this should solve a compatibility issue with the usage of count() on a string see http://php.net/manual/en/migration72.incompatible.php for more