### PR TITLE
Improve DB naming

### DIFF
--- a/src/Amp/Database/MySQL.php
+++ b/src/Amp/Database/MySQL.php
@@ -53,6 +53,7 @@ class MySQL implements DatabaseManagementInterface {
   public function createDatasource($hint) {
     $pass = \Amp\Util\StringUtil::createRandom(16);
     $user = \Amp\Util\StringUtil::createHintedRandom($hint, 16, 5, 'abcdefghijklmnopqrstuvwxyz0123456789');
+    $db = \Amp\Util\StringUtil::createHintedRandom($hint, 32, 5, 'abcdefghijklmnopqrstuvwxyz0123456789');
 
     $datasource = new Datasource();
     $datasource->setDriver($this->adminDatasource->getDriver());
@@ -61,7 +62,7 @@ class MySQL implements DatabaseManagementInterface {
     $datasource->setSocketPath($this->adminDatasource->getSocketPath());
     $datasource->setUsername($user);
     $datasource->setPassword($pass);
-    $datasource->setDatabase($user);
+    $datasource->setDatabase($db);
 
     return $datasource;
   }

--- a/src/Amp/Database/MySQLRAMServer.php
+++ b/src/Amp/Database/MySQLRAMServer.php
@@ -83,6 +83,7 @@ class MySQLRAMServer extends MySQL {
     }
     $pass = \Amp\Util\StringUtil::createRandom(16);
     $user = \Amp\Util\StringUtil::createHintedRandom($hint, 16, 5, 'abcdefghijklmnopqrstuvwxyz0123456789');
+    $db = \Amp\Util\StringUtil::createHintedRandom($hint, 32, 5, 'abcdefghijklmnopqrstuvwxyz0123456789');
 
     $datasource = new Datasource();
     $datasource->setDriver($this->adminDatasource->getDriver());
@@ -91,7 +92,7 @@ class MySQLRAMServer extends MySQL {
     $datasource->setSocketPath($this->mysqld_socket_path);
     $datasource->setUsername($user);
     $datasource->setPassword($pass);
-    $datasource->setDatabase($user);
+    $datasource->setDatabase($db);
 
     return $datasource;
   }


### PR DESCRIPTION
1. When looking at the folder structure to pick a "hint" word, ignore trailing `web/` or `htdocs/`
2. Allow the DB name to be longer (#51)