### PR TITLE
Split out create user from grant for MySQL8 compatibility 

### DIFF
--- a/src/Amp/Database/MySQL.php
+++ b/src/Amp/Database/MySQL.php
@@ -80,17 +80,23 @@ class MySQL implements DatabaseManagementInterface {
 
     $dbh = $this->adminDatasource->createPDO();
     $dbh->exec("CREATE DATABASE `$db`");
+    $version = $dbh->query("SELECT version()")->fetchAll()[0]['version()'];
+    $versionParts = explode('-', $version);
+    $createUserStatement = "CREATE USER";
+    if (version_compare($versionParts[0], '5.5', '>')) {
+      $createUserStatement .= " IF NOT EXISTS";
+    }
     switch ($perm) {
       case DatabaseManagementInterface::PERM_SUPER:
-        $dbh->exec("CREATE USER IF NOT EXISTS '$user'@'localhost' IDENTIFIED WITH mysql_native_password BY '$pass'");
-        $dbh->exec("CREATE USER IF NOT EXISTS '$user'@'%' IDENTIFIED WITH mysql_native_password BY '$pass'");
+        $dbh->exec("$createUserStatement '$user'@'localhost' IDENTIFIED WITH mysql_native_password BY '$pass'");
+        $dbh->exec("$createUserStatement '$user'@'%' IDENTIFIED WITH mysql_native_password BY '$pass'");
         $dbh->exec("GRANT ALL ON *.* to '$user'@'localhost' WITH GRANT OPTION");
         $dbh->exec("GRANT ALL ON *.* to '$user'@'%' WITH GRANT OPTION");
         break;
 
       case DatabaseManagementInterface::PERM_ADMIN:
-        $dbh->exec("CREATE USER IF NOT EXISTS '$user'@'localhost' IDENTIFIED WITH mysql_native_password BY '$pass'");
-        $dbh->exec("CREATE USER IF NOT EXISTS '$user'@'%' IDENTIFIED WITH mysql_native_password BY '$pass'");
+        $dbh->exec("$createUserStatement '$user'@'localhost' IDENTIFIED WITH mysql_native_password BY '$pass'");
+        $dbh->exec("$createUserStatement '$user'@'%' IDENTIFIED WITH mysql_native_password BY '$pass'");
         $dbh->exec("GRANT ALL ON `$db`.* to '$user'@'localhost'");
         $dbh->exec("GRANT ALL ON `$db`.* to '$user'@'%'");
         break;

--- a/src/Amp/Database/MySQL.php
+++ b/src/Amp/Database/MySQL.php
@@ -83,20 +83,22 @@ class MySQL implements DatabaseManagementInterface {
     $version = $dbh->query("SELECT version()")->fetchAll()[0]['version()'];
     $versionParts = explode('-', $version);
     $createUserStatement = "CREATE USER";
-    if (version_compare($versionParts[0], '5.5', '>')) {
+    $authenticationStatment = "IDENTIFIED BY";
+    if (version_compare($versionParts[0], '5.6.0', '>=')) {
       $createUserStatement .= " IF NOT EXISTS";
+      $authenticationStatment = "IDENTIFIED WITH mysql_native_password BY";
     }
     switch ($perm) {
       case DatabaseManagementInterface::PERM_SUPER:
-        $dbh->exec("$createUserStatement '$user'@'localhost' IDENTIFIED WITH mysql_native_password BY '$pass'");
-        $dbh->exec("$createUserStatement '$user'@'%' IDENTIFIED WITH mysql_native_password BY '$pass'");
+        $dbh->exec("$createUserStatement '$user'@'localhost' $authenticationStatment '$pass'");
+        $dbh->exec("$createUserStatement '$user'@'%' $authenticationStatment '$pass'");
         $dbh->exec("GRANT ALL ON *.* to '$user'@'localhost' WITH GRANT OPTION");
         $dbh->exec("GRANT ALL ON *.* to '$user'@'%' WITH GRANT OPTION");
         break;
 
       case DatabaseManagementInterface::PERM_ADMIN:
-        $dbh->exec("$createUserStatement '$user'@'localhost' IDENTIFIED WITH mysql_native_password BY '$pass'");
-        $dbh->exec("$createUserStatement '$user'@'%' IDENTIFIED WITH mysql_native_password BY '$pass'");
+        $dbh->exec("$createUserStatement '$user'@'localhost' $authenticationStatment '$pass'");
+        $dbh->exec("$createUserStatement '$user'@'%' $authenticationStatment '$pass'");
         $dbh->exec("GRANT ALL ON `$db`.* to '$user'@'localhost'");
         $dbh->exec("GRANT ALL ON `$db`.* to '$user'@'%'");
         break;

--- a/src/Amp/Database/MySQL.php
+++ b/src/Amp/Database/MySQL.php
@@ -82,13 +82,17 @@ class MySQL implements DatabaseManagementInterface {
     $dbh->exec("CREATE DATABASE `$db`");
     switch ($perm) {
       case DatabaseManagementInterface::PERM_SUPER:
-        $dbh->exec("GRANT ALL ON *.* to '$user'@'localhost' IDENTIFIED BY '$pass' WITH GRANT OPTION");
-        $dbh->exec("GRANT ALL ON *.* to '$user'@'%' IDENTIFIED BY '$pass' WITH GRANT OPTION");
+        $dbh->exec("CREATE USER IF NOT EXISTS '$user'@'localhost' IDENTIFIED WITH mysql_native_password BY '$pass'");
+        $dbh->exec("CREATE USER IF NOT EXISTS '$user'@'%' IDENTIFIED WITH mysql_native_password BY '$pass'");
+        $dbh->exec("GRANT ALL ON *.* to '$user'@'localhost' WITH GRANT OPTION");
+        $dbh->exec("GRANT ALL ON *.* to '$user'@'%' WITH GRANT OPTION");
         break;
 
       case DatabaseManagementInterface::PERM_ADMIN:
-        $dbh->exec("GRANT ALL ON `$db`.* to '$user'@'localhost' IDENTIFIED BY '$pass'");
-        $dbh->exec("GRANT ALL ON `$db`.* to '$user'@'%' IDENTIFIED BY '$pass'");
+        $dbh->exec("CREATE USER IF NOT EXISTS '$user'@'localhost' IDENTIFIED WITH mysql_native_password BY '$pass'");
+        $dbh->exec("CREATE USER IF NOT EXISTS '$user'@'%' IDENTIFIED WITH mysql_native_password BY '$pass'");
+        $dbh->exec("GRANT ALL ON `$db`.* to '$user'@'localhost'");
+        $dbh->exec("GRANT ALL ON `$db`.* to '$user'@'%'");
         break;
 
       default:


### PR DESCRIPTION
As per the MySQL upgrade docs @totten 

"The following features related to account management are removed:

Using GRANT to create users. Instead, use CREATE USER. Following this practice makes the NO_AUTO_CREATE_USER SQL mode immaterial for GRANT statements, so it too is removed, and an error now is written to the server log when the presence of this value for the sql_mode option in the options file prevents mysqld from starting.

Using GRANT to modify account properties other than privilege assignments. This includes authentication, SSL, and resource-limit properties. Instead, establish such properties at account-creation time with CREATE USER or modify them afterward with ALTER USER.

IDENTIFIED BY PASSWORD 'auth_string' syntax for CREATE USER and GRANT. Instead, use IDENTIFIED WITH auth_plugin AS 'auth_string' for CREATE USER and ALTER USER, where the 'auth_string' value is in a format compatible with the named plugin." 

From https://dev.mysql.com/doc/refman/8.0/en/mysql-nutshell.html#mysql-nutshell-removals

ping @joemurray @monishdeb