### PR TITLE
Do not try and load init files for MySQL version 8 and only pass in t…

### DIFF
--- a/src/Amp/Database/MySQLFactoryHelper.php
+++ b/src/Amp/Database/MySQLFactoryHelper.php
@@ -31,10 +31,26 @@ class MySQLFactoryHelper {
     return $server;
   }
 
+  protected static function getVersion($mysqldBin) {
+    $output = `{$mysqldBin}  --version`;
+    if (preg_match(';mysqld(.bin)?\s+Ver ([0-9][0-9\.+\-a-zA-Z]*)\s;', $output, $matches)) {
+      return $matches[2];
+    }
+    else {
+      throw new \RuntimeException("Failed to determine mysqld version. (\"$output\")");
+    }
+  }
+
   public static function findDataFiles($mysqldBin) {
     $mysqldBin = Process::findExecutable($mysqldBin);
 
     $filesets = array();
+
+    $mysqlVersion = self::getVersion($mysqldBin);
+
+    if (version_compare($mysqlVersion, '6.0', '>')) {
+      return $filesets;
+    }
 
     if (preg_match(';^/nix/;', $mysqldBin)) {
       $dir = dirname(dirname($mysqldBin));

--- a/src/Amp/Database/MySQLRAMServer.php
+++ b/src/Amp/Database/MySQLRAMServer.php
@@ -158,8 +158,6 @@ class MySQLRAMServer extends MySQL {
     $parts[] = "--port=" . escapeshellarg($this->mysqld_port);
     $parts[] = "--socket=" . escapeshellarg($this->mysqld_socket_path);
     $parts[] = "--pid-file=" . escapeshellarg($this->mysqld_pid_path);
-    $parts[] = "--innodb-file-per-table";
-    $parts[] = "--innodb-file-format=Barracuda";
 
     $uname = function_exists('posix_uname') ? posix_uname() : NULL;
     if ($uname && $uname['sysname'] === 'Darwin') {
@@ -223,6 +221,14 @@ class MySQLRAMServer extends MySQL {
     $options .= ' --default-storage-engine=innodb';
     $options .= ' --max_allowed_packet=8M';
     $options .= ' --net_buffer_length=16K';
+
+    if (version_compare($mysqldVersion, '8.0', '<')) {
+      $options .= ' --innodb-file-format=Barracuda';
+      $options .= ' --innodb-file-per-table';
+    }
+    else {
+      $options .= ' --default-authentication-plugin=mysql_native_password';
+    }
 
     return "{$this->getMySQLDBaseCommand()} $options $pipe";
   }


### PR DESCRIPTION
…he file format options and file per table options if less than MySQL8 for MySQL8 specify to use yhe mysql native password as the default authentication plugin

ping @totten @joemurray @monishdeb

This aims to fix 2 issues

1) failing to initialise the ram disk mysql database when doing `amp test` because it throws a "Failed to locate MySQL initialization files". Those files are no longer relevant for MySQL8 and have been ripped out of the distribution as per "These scripts are no longer included in RPM packages (they are unnecessary because they are compiled into the mysqld binary): fill_help_tables.sql, mysql_sys_schema.sql, mysql_system_tables.sql, mysql_system_tables_data.sql, mysql_system_users.sql. (Bug #27672991)" from https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-13.html

2) When the root account for the ram disk is initially created in MySQL8 the default authentication plugin is caching_sha2_password however with the specific version of php included in the bknix i was running into errors such as the following https://bugs.php.net/bug.php?id=76243