### PR TITLE
Fix to work with amp on MariaDB

### DIFF
--- a/src/Amp/Database/MySQL.php
+++ b/src/Amp/Database/MySQL.php
@@ -90,9 +90,11 @@ class MySQL implements DatabaseManagementInterface {
       $authenticationStatment = "IDENTIFIED WITH mysql_native_password BY";
       if (strpos($version, 'MariaDB') !== FALSE) {
         $dbh->exec("$createUserStatement '$user'@'localhost'");
-        $dbh->exec("ALTER USER '$user'@'localhost' IDENTIFIED BY '$pass'");
         $dbh->exec("$createUserStatement '$user'@'%'");
-        $dbh->exec("ALTER USER '$user'@'%' IDENTIFIED BY '$pass'");
+        if (version_compare($versionParts[0], '10.2', '<')) {
+          $dbh->exec("SET PASSWORD for '$user'@'localhost' = PASSWORD('$pass')");
+          $dbh->exec("SET PASSWORD for '$user'@'%' = PASSWORD('$pass')");
+        }
       }
       else {
         $dbh->exec("$createUserStatement '$user'@'localhost'");

--- a/src/Amp/Database/MySQL.php
+++ b/src/Amp/Database/MySQL.php
@@ -88,10 +88,18 @@ class MySQL implements DatabaseManagementInterface {
     if ($alterUser) {
       $createUserStatement .= " IF NOT EXISTS";
       $authenticationStatment = "IDENTIFIED WITH mysql_native_password BY";
-      $dbh->exec("$createUserStatement '$user'@'localhost'");
-      $dbh->exec("ALTER USER '$user'@'localhost' $authenticationStatment '$pass'");
-      $dbh->exec("$createUserStatement '$user'@'%'");
-      $dbh->exec("ALTER USER '$user'@'%' $authenticationStatment '$pass'");
+      if (strpos($version, 'MariaDB') !== FALSE) {
+        $dbh->exec("$createUserStatement '$user'@'localhost'");
+        $dbh->exec("ALTER USER '$user'@'localhost' IDENTIFIED BY '$pass'");
+        $dbh->exec("$createUserStatement '$user'@'%'");
+        $dbh->exec("ALTER USER '$user'@'%' IDENTIFIED BY '$pass'");
+      }
+      else {
+        $dbh->exec("$createUserStatement '$user'@'localhost'");
+        $dbh->exec("ALTER USER '$user'@'localhost' $authenticationStatment '$pass'");
+        $dbh->exec("$createUserStatement '$user'@'%'");
+        $dbh->exec("ALTER USER '$user'@'%' $authenticationStatment '$pass'");
+      }
     }
     else {
       $hosts = ['localhost', '%'];

--- a/src/Amp/Database/MySQL.php
+++ b/src/Amp/Database/MySQL.php
@@ -95,6 +95,10 @@ class MySQL implements DatabaseManagementInterface {
           $dbh->exec("SET PASSWORD for '$user'@'localhost' = PASSWORD('$pass')");
           $dbh->exec("SET PASSWORD for '$user'@'%' = PASSWORD('$pass')");
         }
+        else {
+          $dbh->exec("ALTER USER '$user'@'localhost' IDENTIFIED BY '$pass'");
+          $dbh->exec("ALTER USER '$user'@'%' IDENTIFIED BY '$pass'");
+        }
       }
       else {
         $dbh->exec("$createUserStatement '$user'@'localhost'");


### PR DESCRIPTION
Looking at this it seems as tho in MariaDB when you specify the authentication plugin it expects something slightly differently to MySQL