### PR TITLE
Disable binary logging for MySQL 8

### DIFF
--- a/src/Amp/Database/MySQLRAMServer.php
+++ b/src/Amp/Database/MySQLRAMServer.php
@@ -168,6 +168,12 @@ class MySQLRAMServer extends MySQL {
       $parts[] = "--max-allowed-packet=256M";
     }
 
+    $mysqldVersion = $this->getVersion();
+    // In MySQL 8 Binary logging is turned on bydefault
+    if (version_compare($mysqldVersion, '8.0', '>=')) {
+      $parts[] = '--disable-log-bin';
+    }
+
     return "{$this->mysqld_bin} --no-defaults " . implode(' ', $parts);
   }
 


### PR DESCRIPTION
@totten as per the documentation here https://dev.mysql.com/doc/refman/8.0/en/replication-options-binary-log.html#option_mysqld_log-bin it points to the fact that Binary logging is now on by default in MySQL 8 (what was chewing our mysql disk space). In an effort to ensure we don't run into disk space, i have deployed this via a rebuild phar onto edge profile in test-3 and restarted the mysql server and confirmed binary logging is now off