### PR TITLE
Ensure that innodb-large-prefix is enabled on MySQL 5.5. or less

### DIFF
--- a/src/Amp/Database/MySQLRAMServer.php
+++ b/src/Amp/Database/MySQLRAMServer.php
@@ -165,6 +165,9 @@ class MySQLRAMServer extends MySQL {
       $parts[] = ' --innodb-file-format=Barracuda';
       $parts[] = ' --innodb-file-per-table';
     }
+    if (version_compare($mysqldVersion, '5.7', '<')) {
+      $parts[] = ' --innodb-large-prefix=TRUE';
+    }
 
     $uname = function_exists('posix_uname') ? posix_uname() : NULL;
     if ($uname && $uname['sysname'] === 'Darwin') {


### PR DESCRIPTION
This aims to fix the failing unit test https://test.civicrm.org/job/CiviCRM-Core-Matrix/BKPROF=min,CIVIVER=master,label=bknix-tmp/lastCompletedBuild/testReport/(root)/api_v3_SystemTest/testSystemUTFMB8Conversion/ which only occurs on the min profile