### PR TITLE
Enable large file prefix setting for MySQL 5.6 to fix test failures

### DIFF
--- a/src/Amp/Database/MySQLRAMServer.php
+++ b/src/Amp/Database/MySQLRAMServer.php
@@ -166,6 +166,11 @@ class MySQLRAMServer extends MySQL {
       $parts[] = ' --innodb-file-per-table';
     }
 
+    // Enable innodb-large-prefix on MySQL 5.6 versions.
+    if (version_compare($mysqldVersion, '5.7', '<') && version_compare($mysqldVersion, '5.6', '>=')) {
+      $parts[] = ' --innodb-large-prefix=TRUE';
+    }
+
     $uname = function_exists('posix_uname') ? posix_uname() : NULL;
     if ($uname && $uname['sysname'] === 'Darwin') {
       // Mitigation for "File Descriptor n exceedeed FD_SETSIZE" when using several large builds


### PR DESCRIPTION
@totten it seems we started seeing issues around the key length again after upgrading to MySQL 5.6 e.g. https://test.civicrm.org/job/CiviCRM-Core-Matrix/8168/BKPROF=min,CIVIVER=5.27,SUITES=phpunit-api3,label=bknix-tmp/testReport/junit/(root)/api_v3_ContactTest/testGetWithCustomOfActivityType/ https://test.civicrm.org/job/CiviCRM-Core-Matrix/8168/BKPROF=min,CIVIVER=5.26,SUITES=phpunit-crm,label=bknix-tmp/testReport/junit/(root)/CRM_Contact_BAO_SavedSearchTest/testGetFormValuesWithCustomFields/ https://test.civicrm.org/job/CiviCRM-Core-Matrix/8168/BKPROF=min,CIVIVER=5.26,SUITES=phpunit-api3,label=bknix-tmp/testReport/junit/(root)/api_v3_ReportTemplateTest/testReportsCustomDataOrderBy_with_data_set__3/

This aims to fix this and I have done a manual build of amp and pushed that onto test-1 min profile and currently running a manual matrix to see if this will fix things https://test.civicrm.org/job/CiviCRM-Core-Matrix/8169/