### PR TITLE
Specify utf8mb4 charset when creating the dbs

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -86,6 +86,6 @@ pushd "$PRJDIR"
   test_ramdisk_nix mysql55 https://github.com/NixOS/nixpkgs-channels/archive/nixos-18.09.tar.gz
   test_ramdisk_nix mysql57 https://github.com/NixOS/nixpkgs-channels/archive/nixos-18.09.tar.gz
   test_ramdisk_nix mariadb https://github.com/NixOS/nixpkgs-channels/archive/nixos-18.09.tar.gz
-  test_ramdisk_nix mysql80 https://github.com/NixOS/nixpkgs-channels/archive/d5291756487d70bc336e33512a9baf9fa1788faf.tar.gz
+  test_ramdisk_nix mysql80 https://github.com/NixOS/nixpkgs/archive/20.09.tar.gz
 popd
 exit $EXIT_CODE

--- a/src/Amp/Database/Datasource.php
+++ b/src/Amp/Database/Datasource.php
@@ -165,7 +165,7 @@ class Datasource {
 
   function toPDODSN($options = array()) {
     $pdo_dsn = "{$this->driver}:";
-    $pdo_dsn_options = array();
+    $pdo_dsn_options = array('charset=utf8mb4');
     $settings_to_pdo_options = static::$settings_to_pdo_options;
     if (isset($options['no_database']) && $options['no_database']) {
       unset($settings_to_pdo_options['database']);

--- a/src/Amp/Database/MySQL.php
+++ b/src/Amp/Database/MySQL.php
@@ -79,7 +79,7 @@ class MySQL implements DatabaseManagementInterface {
     $pass = $datasource->getPassword();
 
     $dbh = $this->adminDatasource->createPDO();
-    $dbh->exec("CREATE DATABASE `$db`");
+    $dbh->exec("CREATE DATABASE `$db` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
     $version = $dbh->query("SELECT version()")->fetchAll()[0]['version()'];
     $versionParts = explode('-', $version);
     $createUserStatement = "CREATE USER";


### PR DESCRIPTION
We now default to utf8mb4 on new installs. The civicrm install script hard codes the charset but extensions that have been updated
for the new default no longer do and will pick up the database default

The normal mysql default is 'latin' so this would be be 'no worse' than that.

Note amp is primarily used in dev installs