### PR TITLE
run-tests.sh - Some modernizations

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,7 @@
 ## NOTE: This file has only be used for local development shells.  It has
 ## not be tested for use as a deployment script.
 
-{pkgs ? import (fetchTarball { url = "https://github.com/nixos/nixpkgs/archive/7e9b0dff974c89e070da1ad85713ff3c20b0ca97.tar.gz"; sha256 = "1ckzhh24mgz6jd1xhfgx0i9mijk6xjqxwsshnvq789xsavrmsc36"; }) {
+{pkgs ? import (fetchTarball { url = "https://github.com/nixos/nixpkgs/archive/6794a2c3f67a92f374e02c52edf6442b21a52ecb.tar.gz"; sha256 = "05dyh9lbqijbafzzdjvha6jczcji753vrr5nkz34bbcn61anm4cw"; }) {
     inherit system;
   },
   system ? builtins.currentSystem,

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -17,6 +17,14 @@ function absdirname() {
   popd >> /dev/null
 }
 
+function nixrun() {
+  # nix run "$@"
+  ## ^^^ Nix 2.3? 2.4? Something like that. No longer works in 2.7.
+  # https://github.com/NixOS/nix/issues/5081 + https://discourse.nixos.org/t/error-experimental-nix-feature-nix-command-is-disabled/18089/2
+  nix --extra-experimental-features nix-command shell "$@"
+  return $?
+}
+
 ###############################################################################
 ## Execute the mysqld integration tests using the "ramdisk" style
 ## usage: test_ramdisk_nix <mysql-pkg-name> <nix-repo-url>
@@ -28,9 +36,9 @@ function test_ramdisk_nix() {
   echo "[$name] Start"
 
   ## TIP: If one of these tests fails, then manually start the given daemon with:
-  ## $ nix run -f <url> <pkg> -c test-amp-ramdisk amp mysql:start
+  ## $ nixrun -f <url> <pkg> -c test-amp-ramdisk amp mysql:start
 
-  if nix run -f "$url" "$pkg" -c test-amp-ramdisk "$PHPUNIT" --group mysqld ; then
+  if nixrun -f "$url" "$pkg" -c test-amp-ramdisk "$PHPUNIT" --group mysqld ; then
     echo "[$name] OK"
   else
     echo "[$name] Fail"
@@ -48,7 +56,7 @@ function test_phpunit() {
   shift 2
   local name="Unit tests ($pkg from $url; $@)"
   echo "[$name] Start"
-  if nix run -f "$url" "$pkg" -c php $(which "$PHPUNIT") "$@" ; then
+  if nixrun -f "$url" "$pkg" -c php $(which "$PHPUNIT") "$@" ; then
     echo "[$name] OK"
   else
     echo "[$name] Fail"

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -79,6 +79,8 @@ if [ ! -f "$PRJDIR/bin/amp" ]; then
   exit 1
 fi
 
+PIN_2205="https://github.com/nixos/nixpkgs/archive/6794a2c3f67a92f374e02c52edf6442b21a52ecb.tar.gz"
+
 EXIT_CODE=0
 pushd "$PRJDIR"
   "$COMPOSER" install
@@ -87,14 +89,14 @@ pushd "$PRJDIR"
 
   ## (1) The 'unit' tests are lower-level tests for PHP classes/functions. These are executed with multiple versions of PHP.
   test_phpunit     php72   https://github.com/NixOS/nixpkgs-channels/archive/nixos-18.09.tar.gz --group unit
-  test_phpunit     php74   https://github.com/NixOS/nixpkgs-channels/archive/nixos-20.03.tar.gz --group unit
-  test_phpunit     php80   https://github.com/nixos/nixpkgs/archive/594fbfe27905f2fd98d9431038814e497b4fcad1.tar.gz --group unit
-  test_phpunit     php81   https://github.com/nixos/nixpkgs/archive/6794a2c3f67a92f374e02c52edf6442b21a52ecb.tar.gz --group unit
+  test_phpunit     php74   "$PIN_2205" --group unit
+  test_phpunit     php80   "$PIN_2205" --group unit
+  test_phpunit     php81   "$PIN_2205" --group unit
 
   ## (2) The 'mysqld' tests are higher-level integration tests for working with the DBMS. These are executed with multiple versions of MySQL.
   test_ramdisk_nix mysql55 https://github.com/NixOS/nixpkgs-channels/archive/nixos-18.09.tar.gz
   test_ramdisk_nix mysql57 https://github.com/NixOS/nixpkgs-channels/archive/nixos-18.09.tar.gz
   test_ramdisk_nix mariadb https://github.com/NixOS/nixpkgs-channels/archive/nixos-18.09.tar.gz
-  test_ramdisk_nix mysql80 https://github.com/NixOS/nixpkgs/archive/20.09.tar.gz
+  test_ramdisk_nix mysql80 "$PIN_2205"
 popd
 exit $EXIT_CODE


### PR DESCRIPTION
A few updates to the `run-tests.sh` stuff so that that it runs (a) with newer version of `nix` cli and (b) runs at least some tests on a pre-release of nixpkgs 22.05 (which has better build support for current Macs).

Tested on Ubuntu Focal/x64/nix-2.7 (*where everything passes*) and macOS Monterey/M1/nix-2.5 (*where the buildable things passed; but some older php+mysql weren't buildable*).